### PR TITLE
fix(order): fix incorrect relationship between orders and items

### DIFF
--- a/src/main/java/com/smarthardwareshop/api/orders/entities/Order.java
+++ b/src/main/java/com/smarthardwareshop/api/orders/entities/Order.java
@@ -44,6 +44,6 @@ public @Data class Order extends IdentifiableEntity {
     /**
      * The order items.
      */
-    @OneToMany(cascade = { CascadeType.ALL }, mappedBy = "order")
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "order", orphanRemoval = true)
     private List<OrderItem> items = new ArrayList<>();
 }

--- a/src/main/java/com/smarthardwareshop/api/orders/entities/OrderItem.java
+++ b/src/main/java/com/smarthardwareshop/api/orders/entities/OrderItem.java
@@ -28,7 +28,7 @@ public @Data class OrderItem extends IdentifiableEntity {
     /**
      * The order items.
      */
-    @ManyToOne(cascade = CascadeType.ALL)
-    @PrimaryKeyJoinColumn
+    @ManyToOne()
+    @JoinColumn(name = "order_id", referencedColumnName = "id")
     private Order order;
 }


### PR DESCRIPTION
Fixes an wrong behaviour in which order items are not removed on update by performing the following steps:

- Adding missing "orphanRemoval = true" configuration
- Removing incorrect cascade configuration (in this case, the cascade should be in the order class only)
- Replaced incorrect use of `@PrimaryKeyJoinColumn` annotation with a proper `@JoinColumn`. The `@PrimaryKeyJoinColumn` annotation should be used to specify a primary key column that is used as a foreign key to join to another table. Thus, it is not intended to be used here.